### PR TITLE
Add Security Headers Middleware and Tests

### DIFF
--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class SecurityHeaders
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        /** @var \Illuminate\Http\Response|\Illuminate\Http\JsonResponse $response */
+        $response = $next($request);
+
+        $response->headers->set('Strict-Transport-Security', 'max-age=63072000; includeSubDomains; preload');
+        $response->headers->set('X-Content-Type-Options', 'nosniff');
+        $response->headers->set('X-Frame-Options', 'SAMEORIGIN');
+        $response->headers->set('Content-Security-Policy', "default-src 'self'");
+        $response->headers->set('Referrer-Policy', 'no-referrer');
+        $response->headers->set('X-XSS-Protection', '1; mode=block');
+        $response->headers->remove('Server');
+
+        return $response;
+    }
+}
+

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -22,12 +22,16 @@ return Application::configure(basePath: dirname(__DIR__))
     $middleware->alias([
       'admin' => \App\Http\Middleware\AdminMiddleware::class,
       'check.user.status' => \App\Http\Middleware\CheckUserStatus::class,
+      'security.headers' => \App\Http\Middleware\SecurityHeaders::class,
     ]);
 
     // 既存のCSRFミドルウェアをカスタムCSRFミドルウェアに置き換え
     $middleware->web(replace: [
       \Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class => \App\Http\Middleware\VerifyCsrfToken::class,
     ]);
+
+    $middleware->web(append: ['security.headers']);
+    $middleware->api(append: ['security.headers']);
   })
   ->withExceptions(function (Exceptions $exceptions) {
     $exceptions->render(function (AuthenticationException $e, Request $request) {

--- a/tests/Feature/SecurityHeadersTest.php
+++ b/tests/Feature/SecurityHeadersTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class SecurityHeadersTest extends TestCase
+{
+    public function test_hsts_header_exists(): void
+    {
+        $response = $this->get('/');
+        $response->assertHeader('Strict-Transport-Security');
+    }
+
+    public function test_x_content_type_options_nosniff(): void
+    {
+        $response = $this->get('/');
+        $response->assertHeader('X-Content-Type-Options', 'nosniff');
+    }
+
+    public function test_x_frame_options_header(): void
+    {
+        $response = $this->get('/');
+        $this->assertContains(
+            $response->headers->get('X-Frame-Options'),
+            ['DENY', 'SAMEORIGIN']
+        );
+    }
+
+    public function test_content_security_policy_header_exists(): void
+    {
+        $response = $this->get('/');
+        $response->assertHeader('Content-Security-Policy');
+    }
+
+    public function test_referrer_policy_header_exists(): void
+    {
+        $response = $this->get('/');
+        $response->assertHeader('Referrer-Policy');
+    }
+
+    public function test_x_xss_protection_header_exists(): void
+    {
+        $response = $this->get('/');
+        $response->assertHeader('X-XSS-Protection');
+    }
+
+    public function test_server_header_is_hidden_in_api_response(): void
+    {
+        $response = $this->get('/api/config');
+        $this->assertFalse($response->headers->has('Server'));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add SecurityHeaders middleware to set common security headers
- register the new middleware for web and api routes
- create SecurityHeadersTest to verify HSTS, CSP, and other headers

## Testing
- `./vendor/bin/phpunit --filter SecurityHeadersTest`
- `./vendor/bin/phpunit --testsuite Feature` *(fails: 85 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684010ebc488832587d66d4d972f6796