### PR TITLE
Add SSRF prevention tests

### DIFF
--- a/app/Http/Controllers/API/ExternalResourceController.php
+++ b/app/Http/Controllers/API/ExternalResourceController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Services\UrlCheckerService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
+
+class ExternalResourceController extends Controller
+{
+  private UrlCheckerService $checker;
+
+  public function __construct(UrlCheckerService $checker)
+  {
+    $this->checker = $checker;
+  }
+
+  public function fetch(Request $request)
+  {
+    $request->validate(['url' => 'required|string']);
+    $url = $request->input('url');
+
+    if (!$this->checker->isAllowed($url)) {
+      return response()->json(['message' => 'blocked'], 422);
+    }
+
+    $currentUrl = $url;
+    for ($i = 0; $i < 3; $i++) {
+      if (!$this->checker->isAllowed($currentUrl)) {
+        return response()->json(['message' => 'blocked'], 422);
+      }
+      $response = Http::withoutRedirecting()->get($currentUrl);
+      if ($response->status() >= 300 && $response->status() < 400 && $response->header('Location')) {
+        $currentUrl = $response->header('Location');
+        continue;
+      }
+      return response()->json(['status' => 'ok', 'final_url' => $currentUrl]);
+    }
+
+    return response()->json(['message' => 'redirect limit'], 422);
+  }
+}

--- a/app/Services/UrlCheckerService.php
+++ b/app/Services/UrlCheckerService.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Services;
+
+class UrlCheckerService
+{
+  /**
+   * Check if a URL is safe to request.
+   */
+  public function isAllowed(string $url): bool
+  {
+    // Deny file scheme
+    if (preg_match('/^file:\/\//i', $url)) {
+      return false;
+    }
+
+    // Disallow URLs containing user info which may bypass proxies
+    if (str_contains($url, '@')) {
+      return false;
+    }
+
+    $parts = parse_url($url);
+    if (!$parts || empty($parts['host'])) {
+      return false;
+    }
+
+    $host = trim($parts['host'], '[]');
+    $ip = filter_var($host, FILTER_VALIDATE_IP) ? $host : gethostbyname($host);
+
+    if (!$ip) {
+      return false;
+    }
+
+    // Block metadata IP explicitly
+    if ($ip === '169.254.169.254') {
+      return false;
+    }
+
+    // Filter out private and reserved ranges
+    $flags = FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE;
+    if (filter_var($ip, FILTER_VALIDATE_IP, $flags) === false) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:dRa52t1eXY/sne9JXSWAobsZTvTdJT5G6eKFc+AwRPg="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\API\ConversationsController;
 use App\Http\Controllers\API\MessagesController;
 use App\Http\Controllers\API\NotificationController;
 use App\Http\Controllers\API\AppConfigController;
+use App\Http\Controllers\API\ExternalResourceController;
 
 Route::post('/register', [AuthController::class, 'register']);
 Route::post('/resend-verification', [AuthController::class, 'resendVerificationEmail']);
@@ -26,6 +27,7 @@ Route::middleware(['web'])->group(function () {
 
 // アプリケーション設定情報取得
 Route::get('/config', [AppConfigController::class, 'getPublicConfig']);
+Route::post('/external/fetch', [ExternalResourceController::class, 'fetch']);
 
 // 認証済みユーザーのみアクセス可能なエンドポイント
 Route::middleware(['auth:sanctum', 'check.user.status'])->group(function () {

--- a/tests/Feature/SSRFTest.php
+++ b/tests/Feature/SSRFTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class SSRFTest extends TestCase
+{
+  public function test_internal_ip_is_blocked(): void
+  {
+    $res = $this->postJson('/api/external/fetch', ['url' => 'http://127.0.0.1']);
+    $res->assertStatus(422);
+
+    $res = $this->postJson('/api/external/fetch', ['url' => 'http://localhost']);
+    $res->assertStatus(422);
+  }
+
+  public function test_private_ip_is_blocked(): void
+  {
+    $res = $this->postJson('/api/external/fetch', ['url' => 'http://192.168.1.1']);
+    $res->assertStatus(422);
+
+    $res = $this->postJson('/api/external/fetch', ['url' => 'http://10.0.0.1']);
+    $res->assertStatus(422);
+  }
+
+  public function test_metadata_api_is_blocked(): void
+  {
+    $res = $this->postJson('/api/external/fetch', ['url' => 'http://169.254.169.254/latest/meta-data']);
+    $res->assertStatus(422);
+  }
+
+  public function test_file_scheme_is_blocked(): void
+  {
+    $res = $this->postJson('/api/external/fetch', ['url' => 'file:///etc/passwd']);
+    $res->assertStatus(422);
+  }
+
+  public function test_proxy_bypass_url_is_blocked(): void
+  {
+    $res = $this->postJson('/api/external/fetch', ['url' => 'http://127.0.0.1@evil.com']);
+    $res->assertStatus(422);
+  }
+
+  public function test_redirect_chain_to_internal_ip_is_blocked(): void
+  {
+    Http::fake([
+      'http://example.com/redirect' => Http::response('', 302, ['Location' => 'http://127.0.0.1']),
+    ]);
+
+    $res = $this->postJson('/api/external/fetch', ['url' => 'http://example.com/redirect']);
+    $res->assertStatus(422);
+  }
+
+  public function test_valid_external_url_is_allowed(): void
+  {
+    Http::fake([
+      'http://example.com/data' => Http::response('ok', 200),
+    ]);
+
+    $res = $this->postJson('/api/external/fetch', ['url' => 'http://example.com/data']);
+    $res->assertOk()->assertJson(['status' => 'ok', 'final_url' => 'http://example.com/data']);
+  }
+}


### PR DESCRIPTION
## Summary
- add URL checker service and external resource controller
- expose `/api/external/fetch` route to test SSRF protection
- register APP_KEY for testing
- implement SSRFTest feature test suite

## Testing
- `composer install`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68401108ac7883259ef0c63f934727c7