### PR TITLE
操作ログ機能の追加

### DIFF
--- a/app/Http/Controllers/Admin/AdminAuthController.php
+++ b/app/Http/Controllers/Admin/AdminAuthController.php
@@ -53,6 +53,7 @@ class AdminAuthController extends Controller
         'ip' => $request->ip(),
         'user_agent' => $request->userAgent()
       ]);
+      \App\Services\OperationLogService::log('backend', 'admin_login', 'admin_id:' . Auth::guard('admin')->id());
 
       return redirect()->intended(route('admin.dashboard'));
     }
@@ -86,6 +87,7 @@ class AdminAuthController extends Controller
       'ip' => $request->ip(),
       'user_agent' => $request->userAgent()
     ]);
+    \App\Services\OperationLogService::log('backend', 'admin_logout', 'admin_id:' . ($admin ? $admin->id : ''));
 
     Auth::guard('admin')->logout();
 

--- a/app/Http/Controllers/GoogleAuthController.php
+++ b/app/Http/Controllers/GoogleAuthController.php
@@ -139,6 +139,7 @@ class GoogleAuthController extends Controller
         ]);
 
         Log::info('新規ユーザーが作成されました', ['user_id' => $user->id]);
+        \App\Services\OperationLogService::log('frontend', 'user_register', 'user_id:' . $user->id . ' google:true');
       }
 
       // 共通の処理
@@ -181,6 +182,7 @@ class GoogleAuthController extends Controller
         'user_id' => $user->id,
         'email' => $user->email
       ]);
+      \App\Services\OperationLogService::log('frontend', 'user_login', 'user_id:' . $user->id . ' google:true');
 
       // フロントエンドにトークンを渡してリダイレクト
       return $this->redirectWithSuccess($tokenResult->plainTextToken, $user);

--- a/app/Models/OperationLog.php
+++ b/app/Models/OperationLog.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class OperationLog extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'category',
+        'action',
+        'description',
+    ];
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -309,7 +309,15 @@ class User extends Authenticatable
     }
 
     $friendship->status = Friendship::STATUS_ACCEPTED;
-    return $friendship->save();
+    $saved = $friendship->save();
+    if ($saved) {
+      \App\Services\OperationLogService::log(
+        'frontend',
+        'friend_accept',
+        'user:' . $this->id . ' friend:' . $userId
+      );
+    }
+    return $saved;
   }
 
   /**

--- a/app/Services/AuthService.php
+++ b/app/Services/AuthService.php
@@ -63,6 +63,7 @@ class AuthService extends BaseService
       // throw new \Exception('テスト用例外: メール送信をスキップ');
 
       DB::commit();
+      \App\Services\OperationLogService::log('frontend', 'user_register', 'user_id:' . $user->id . ' google:false');
     } catch (\Exception $ex) {
       DB::rollBack();
       Log::error('登録処理中にエラーが発生しました: ' . $ex->getMessage(), [
@@ -206,6 +207,7 @@ class AuthService extends BaseService
       ]);
 
       Log::info('ログイン成功', ['user_id' => $user->id, 'email' => $email, 'ip' => $ip]);
+      \App\Services\OperationLogService::log('frontend', 'user_login', 'user_id:' . $user->id);
 
       return [
         'status'       => 'success',

--- a/app/Services/OperationLogService.php
+++ b/app/Services/OperationLogService.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\OperationLog;
+
+class OperationLogService
+{
+    public static function log(string $category, string $action, ?string $description = null): void
+    {
+        OperationLog::create([
+            'category' => $category,
+            'action' => $action,
+            'description' => $description,
+        ]);
+
+        // 古いログを30件に保つ
+        self::trimLogs($category);
+    }
+
+    private static function trimLogs(string $category): void
+    {
+        $logs = OperationLog::where('category', $category)
+            ->orderBy('created_at', 'desc')
+            ->skip(30)
+            ->take(PHP_INT_MAX)
+            ->get();
+        foreach ($logs as $log) {
+            $log->delete();
+        }
+    }
+}

--- a/database/migrations/2025_06_03_100012_create_operation_logs_table.php
+++ b/database/migrations/2025_06_03_100012_create_operation_logs_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('operation_logs', function (Blueprint $table) {
+            $table->id();
+            $table->string('category'); // 'frontend' or 'backend'
+            $table->string('action');
+            $table->text('description')->nullable();
+            $table->timestamps();
+
+            $table->index('category');
+            $table->index('created_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('operation_logs');
+    }
+};

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -235,41 +235,63 @@
   </div>
 </div>
 
-<!-- 最近の活動 -->
+<!-- 操作ログ -->
 <div class="row mt-4">
   <div class="col-12">
     <div class="card">
       <div class="card-header">
         <h5 class="card-title mb-0">
-          <i class="fas fa-history me-2"></i>最近の活動
+          <i class="fas fa-history me-2"></i>操作ログ
         </h5>
       </div>
       <div class="card-body">
-        <div class="d-flex align-items-center py-2">
-          <div class="flex-shrink-0">
-            <i class="fas fa-user-plus text-success me-3"></i>
-          </div>
-          <div class="flex-grow-1">
-            <strong>新規ユーザー登録</strong>
-            <p class="text-muted mb-0">3名の新規ユーザーが登録されました</p>
-          </div>
-          <div class="flex-shrink-0">
-            <small class="text-muted">2時間前</small>
-          </div>
-        </div>
+        <h6 class="fw-bold">フロントエンド</h6>
+        <ul class="list-unstyled">
+          @foreach($frontendLogs->take(10) as $log)
+          <li class="mb-2">
+            <span class="text-muted small">{{ $log->created_at->format('Y-m-d H:i') }}</span>
+            <span class="ms-2">{{ $log->action }} - {{ $log->description }}</span>
+          </li>
+          @endforeach
+        </ul>
+        @if($frontendLogs->count() > 10)
+        <details>
+          <summary class="text-primary">さらに表示</summary>
+          <ul class="list-unstyled mt-2">
+            @foreach($frontendLogs->slice(10) as $log)
+            <li class="mb-2">
+              <span class="text-muted small">{{ $log->created_at->format('Y-m-d H:i') }}</span>
+              <span class="ms-2">{{ $log->action }} - {{ $log->description }}</span>
+            </li>
+            @endforeach
+          </ul>
+        </details>
+        @endif
+
         <hr>
-        <div class="d-flex align-items-center py-2">
-          <div class="flex-shrink-0">
-            <i class="fas fa-sign-in-alt text-primary me-3"></i>
-          </div>
-          <div class="flex-grow-1">
-            <strong>管理者ログイン</strong>
-            <p class="text-muted mb-0">{{ $admin->name }} がログインしました</p>
-          </div>
-          <div class="flex-shrink-0">
-            <small class="text-muted">現在</small>
-          </div>
-        </div>
+
+        <h6 class="fw-bold">バックエンド</h6>
+        <ul class="list-unstyled">
+          @foreach($backendLogs->take(10) as $log)
+          <li class="mb-2">
+            <span class="text-muted small">{{ $log->created_at->format('Y-m-d H:i') }}</span>
+            <span class="ms-2">{{ $log->action }} - {{ $log->description }}</span>
+          </li>
+          @endforeach
+        </ul>
+        @if($backendLogs->count() > 10)
+        <details>
+          <summary class="text-primary">さらに表示</summary>
+          <ul class="list-unstyled mt-2">
+            @foreach($backendLogs->slice(10) as $log)
+            <li class="mb-2">
+              <span class="text-muted small">{{ $log->created_at->format('Y-m-d H:i') }}</span>
+              <span class="ms-2">{{ $log->action }} - {{ $log->description }}</span>
+            </li>
+            @endforeach
+          </ul>
+        </details>
+        @endif
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add operation_logs table
- add OperationLog model and service
- log key user and admin actions
- show frontend/backend logs on dashboard

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68411ad3700883258718c266414cbbbd