### PR TITLE
Add comprehensive tests for OperationLogService

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "doctrine/dbal": "^4.2",
         "laravel-notification-channels/webpush": "^10.2",
         "laravel/framework": "^11.31",
         "laravel/reverb": "^1.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c76d007383725eb992d44652732badb9",
+    "content-hash": "217472acb3fd109b0884d9d38118d51c",
     "packages": [
         {
             "name": "brick/math",
@@ -339,6 +339,160 @@
                 "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.3"
             },
             "time": "2024-07-08T12:26:09+00:00"
+        },
+        {
+            "name": "doctrine/dbal",
+            "version": "4.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "33d2d7fe1269b2301640c44cf2896ea607b30e3e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/33d2d7fe1269b2301640c44cf2896ea607b30e3e",
+                "reference": "33d2d7fe1269b2301640c44cf2896ea607b30e3e",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^0.5.3|^1",
+                "php": "^8.1",
+                "psr/cache": "^1|^2|^3",
+                "psr/log": "^1|^2|^3"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "12.0.0",
+                "fig/log-test": "^1",
+                "jetbrains/phpstorm-stubs": "2023.2",
+                "phpstan/phpstan": "2.1.1",
+                "phpstan/phpstan-phpunit": "2.0.3",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "10.5.39",
+                "slevomat/coding-standard": "8.13.1",
+                "squizlabs/php_codesniffer": "3.10.2",
+                "symfony/cache": "^6.3.8|^7.0",
+                "symfony/console": "^5.4|^6.3|^7.0"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\DBAL\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Powerful PHP database abstraction layer (DBAL) with many features for database schema introspection and management.",
+            "homepage": "https://www.doctrine-project.org/projects/dbal.html",
+            "keywords": [
+                "abstraction",
+                "database",
+                "db2",
+                "dbal",
+                "mariadb",
+                "mssql",
+                "mysql",
+                "oci8",
+                "oracle",
+                "pdo",
+                "pgsql",
+                "postgresql",
+                "queryobject",
+                "sasql",
+                "sql",
+                "sqlite",
+                "sqlserver",
+                "sqlsrv"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/dbal/issues",
+                "source": "https://github.com/doctrine/dbal/tree/4.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdbal",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-03-07T18:29:05+00:00"
+        },
+        {
+            "name": "doctrine/deprecations",
+            "version": "1.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
+                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<=7.5 || >=13"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^12 || ^13",
+                "phpstan/phpstan": "1.4.10 || 2.1.11",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.5"
+            },
+            "time": "2025-04-07T20:06:18+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -3628,6 +3782,55 @@
                 }
             ],
             "time": "2024-12-14T21:12:59+00:00"
+        },
+        {
+            "name": "psr/cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+            },
+            "time": "2021-02-03T23:26:27+00:00"
         },
         {
             "name": "psr/clock",

--- a/database/factories/OperationLogFactory.php
+++ b/database/factories/OperationLogFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\OperationLog;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class OperationLogFactory extends Factory
+{
+    protected $model = OperationLog::class;
+
+    public function definition(): array
+    {
+        return [
+            'category' => $this->faker->randomElement(['frontend', 'backend']),
+            'action' => $this->faker->word(),
+            'description' => $this->faker->sentence(),
+        ];
+    }
+}

--- a/database/migrations/2025_06_03_100001_add_soft_delete_columns_to_conversations_table.php
+++ b/database/migrations/2025_06_03_100001_add_soft_delete_columns_to_conversations_table.php
@@ -31,8 +31,11 @@ return new class extends Migration
     // 外部キー制約の追加（既存チェック）
     Schema::table('conversations', function (Blueprint $table) {
       // 外部キー制約が既に存在するかチェック
-      $foreignKeys = Schema::getConnection()->getDoctrineSchemaManager()
-        ->listTableForeignKeys('conversations');
+      $foreignKeys = [];
+      if (method_exists(Schema::getConnection(), 'getDoctrineSchemaManager')) {
+        $foreignKeys = Schema::getConnection()->getDoctrineSchemaManager()
+          ->listTableForeignKeys('conversations');
+      }
 
       $hasDeletedByForeignKey = false;
       foreach ($foreignKeys as $foreignKey) {
@@ -55,8 +58,11 @@ return new class extends Migration
   {
     Schema::table('conversations', function (Blueprint $table) {
       // 外部キー制約の削除（存在チェック付き）
-      $foreignKeys = Schema::getConnection()->getDoctrineSchemaManager()
-        ->listTableForeignKeys('conversations');
+      $foreignKeys = [];
+      if (method_exists(Schema::getConnection(), 'getDoctrineSchemaManager')) {
+        $foreignKeys = Schema::getConnection()->getDoctrineSchemaManager()
+          ->listTableForeignKeys('conversations');
+      }
 
       foreach ($foreignKeys as $foreignKey) {
         if (in_array('deleted_by', $foreignKey->getLocalColumns())) {

--- a/tests/Unit/OperationLogServiceTest.php
+++ b/tests/Unit/OperationLogServiceTest.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\OperationLog;
+use App\Services\OperationLogService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+use Mockery;
+
+class OperationLogServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    private function createLogs(string $category, int $count): void
+    {
+        for ($i = 1; $i <= $count; $i++) {
+            OperationLogService::log($category, "action{$i}");
+        }
+    }
+
+    private function seedLogs(string $category, int $count): void
+    {
+        OperationLog::factory()->count($count)->sequence(fn ($sequence) => [
+            'category' => $category,
+            'action' => 'action' . ($sequence->index + 1),
+            'created_at' => now()->subSeconds($count - $sequence->index),
+        ])->create();
+    }
+
+    public function test_ログ作成_正常ケース(): void
+    {
+        OperationLogService::log('frontend', 'login', '管理画面ログイン');
+
+        $this->assertDatabaseHas('operation_logs', [
+            'category' => 'frontend',
+            'action' => 'login',
+            'description' => '管理画面ログイン',
+        ]);
+    }
+
+    public function test_ログ作成_必須項目のみ(): void
+    {
+        OperationLogService::log('frontend', 'logout');
+
+        $this->assertDatabaseHas('operation_logs', [
+            'category' => 'frontend',
+            'action' => 'logout',
+            'description' => null,
+        ]);
+    }
+
+    public function test_ログ作成_説明なし(): void
+    {
+        OperationLogService::log('backend', 'deploy', null);
+
+        $this->assertDatabaseHas('operation_logs', [
+            'category' => 'backend',
+            'action' => 'deploy',
+            'description' => null,
+        ]);
+    }
+
+    public function test_カテゴリ別ログ管理(): void
+    {
+        OperationLogService::log('frontend', 'a1');
+        OperationLogService::log('backend', 'b1');
+        OperationLogService::log('frontend', 'a2');
+
+        $this->assertEquals(2, OperationLog::where('category', 'frontend')->count());
+        $this->assertEquals(1, OperationLog::where('category', 'backend')->count());
+    }
+
+    public function test_古いログ削除_正確に3000件保持(): void
+    {
+        $this->createLogs('frontend', 3100);
+
+        $this->assertEquals(3000, OperationLog::where('category', 'frontend')->count());
+    }
+
+    public function test_古いログ削除_カテゴリ別独立削除(): void
+    {
+        $this->createLogs('frontend', 3100);
+        $this->createLogs('backend', 3100);
+
+        $this->assertEquals(3000, OperationLog::where('category', 'frontend')->count());
+        $this->assertEquals(3000, OperationLog::where('category', 'backend')->count());
+    }
+
+    public function test_古いログ削除_新しいログは保持される(): void
+    {
+        $this->createLogs('frontend', 3001);
+
+        $newestId = OperationLog::where('category', 'frontend')->max('id');
+        $this->assertDatabaseHas('operation_logs', ['id' => $newestId]);
+    }
+
+    public function test_古いログ削除_最古のログから削除される(): void
+    {
+        $this->seedLogs('frontend', 3000);
+        $oldestId = OperationLog::where('category', 'frontend')->orderBy('created_at')->first()->id;
+        OperationLogService::log('frontend', 'latest');
+
+        $this->assertDatabaseMissing('operation_logs', ['id' => $oldestId]);
+    }
+
+    public function test_ログ件数が3000件未満の場合削除されない(): void
+    {
+        $this->createLogs('frontend', 2999);
+
+        $this->assertEquals(2999, OperationLog::where('category', 'frontend')->count());
+    }
+
+    public function test_ちょうど3000件の場合(): void
+    {
+        $this->createLogs('frontend', 3000);
+
+        $this->assertEquals(3000, OperationLog::where('category', 'frontend')->count());
+    }
+
+    public function test_3001件目で最古が削除される(): void
+    {
+        $this->seedLogs('frontend', 3000);
+        OperationLogService::log('frontend', 'new');
+
+        $this->assertEquals(3000, OperationLog::where('category', 'frontend')->count());
+        $this->assertDatabaseMissing('operation_logs', ['action' => 'action1']);
+    }
+
+    public function test_0件から1件目の作成(): void
+    {
+        OperationLogService::log('frontend', 'first');
+
+        $this->assertEquals(1, OperationLog::where('category', 'frontend')->count());
+    }
+
+    public function test_大量ログでの削除性能(): void
+    {
+        $this->seedLogs('frontend', 10000);
+
+        $start = microtime(true);
+        OperationLogService::log('frontend', 'bulk');
+        $elapsed = microtime(true) - $start;
+
+        $this->assertLessThan(1, $elapsed);
+        $this->assertEquals(3000, OperationLog::where('category', 'frontend')->count());
+    }
+
+    public function test_frontend_backend_独立削除(): void
+    {
+        $this->seedLogs('frontend', 2500);
+        $this->seedLogs('backend', 3500);
+        OperationLogService::log('frontend', 'a');
+        OperationLogService::log('backend', 'b');
+
+        $this->assertEquals(2501, OperationLog::where('category', 'frontend')->count());
+        $this->assertEquals(3000, OperationLog::where('category', 'backend')->count());
+    }
+
+    public function test_削除対象の正確性_作成日時順(): void
+    {
+        $this->seedLogs('frontend', 3050);
+        $deletedId = OperationLog::where('category', 'frontend')->orderBy('created_at')->first()->id;
+        $expectedOldestId = OperationLog::where('category', 'frontend')->orderBy('created_at')->skip(51)->first()->id;
+        OperationLogService::log('frontend', 'latest');
+
+        $this->assertDatabaseMissing('operation_logs', ['id' => $deletedId]);
+        $this->assertDatabaseHas('operation_logs', ['id' => $expectedOldestId]);
+    }
+
+    public function test_同時実行での整合性(): void
+    {
+        $this->seedLogs('frontend', 2999);
+        DB::beginTransaction();
+        OperationLogService::log('frontend', 'within');
+        DB::rollBack();
+
+        $this->assertEquals(2999, OperationLog::where('category', 'frontend')->count());
+    }
+
+    public function test_不正なカテゴリ名での実行(): void
+    {
+        OperationLogService::log('invalid', 'action');
+
+        $this->assertEquals(1, OperationLog::where('category', 'invalid')->count());
+    }
+
+    public function test_データベース例外時の動作(): void
+    {
+        $this->expectException(\Exception::class);
+
+        Mockery::mock('alias:App\\Models\\OperationLog')
+            ->shouldReceive('create')
+            ->andThrow(new \Exception('DB error'));
+
+        OperationLogService::log('frontend', 'fail');
+    }
+}


### PR DESCRIPTION
## Summary
- add DBAL dependency to support schema checks
- skip doctrine checks when method unavailable
- create `OperationLogFactory`
- implement `OperationLogServiceTest` covering logging and trim behaviour

## Testing
- `php artisan test tests/Unit/OperationLogServiceTest.php`

------
https://chatgpt.com/codex/tasks/task_e_684143252d148325878792ba1171e483