### PR TITLE
Improve conversation management tests

### DIFF
--- a/database/factories/ConversationFactory.php
+++ b/database/factories/ConversationFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Conversation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ConversationFactory extends Factory
+{
+    protected $model = Conversation::class;
+
+    public function definition(): array
+    {
+        return [
+            'type' => $this->faker->randomElement(['direct', 'group']),
+            'room_token' => null,
+        ];
+    }
+
+    public function deleted(): static
+    {
+        return $this->state(function (): array {
+            return [
+                'deleted_at' => now(),
+                'deleted_by' => 1,
+                'deleted_reason' => 'テスト削除',
+            ];
+        });
+    }
+}

--- a/database/factories/MessageFactory.php
+++ b/database/factories/MessageFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Message;
+use App\Models\User;
+use App\Models\Conversation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class MessageFactory extends Factory
+{
+    protected $model = Message::class;
+
+    public function definition(): array
+    {
+        return [
+            'conversation_id' => Conversation::factory(),
+            'sender_id' => User::factory(),
+            'admin_sender_id' => null,
+            'content_type' => 'text',
+            'text_content' => $this->faker->sentence(),
+            'sent_at' => now(),
+        ];
+    }
+
+    public function adminMessage($adminId): static
+    {
+        return $this->state(fn(array $attributes) => [
+            'sender_id' => null,
+            'admin_sender_id' => $adminId,
+        ]);
+    }
+}

--- a/tests/Feature/Admin/ConversationManagementTest.php
+++ b/tests/Feature/Admin/ConversationManagementTest.php
@@ -1,0 +1,351 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\Admin;
+use App\Models\Conversation;
+use App\Models\Message;
+use App\Models\Participant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ConversationManagementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createTestConversations()
+    {
+        $userA = User::factory()->create();
+        $userB = User::factory()->create();
+
+        // Normal conversation
+        $conv1 = Conversation::factory()->create(['type' => 'direct']);
+        Participant::create(['conversation_id' => $conv1->id, 'user_id' => $userA->id]);
+        Participant::create(['conversation_id' => $conv1->id, 'user_id' => $userB->id]);
+        Message::factory()->create([
+            'conversation_id' => $conv1->id,
+            'sender_id' => $userA->id,
+            'text_content' => 'hello',
+        ]);
+
+        // Support conversation (excluded)
+        $conv2 = Conversation::factory()->create(['type' => 'support']);
+        Participant::create(['conversation_id' => $conv2->id, 'user_id' => $userA->id]);
+
+        // Deleted conversation
+        $conv3 = Conversation::factory()->create(['type' => 'direct']);
+        Participant::create(['conversation_id' => $conv3->id, 'user_id' => $userA->id]);
+        $conv3->deleteByAdmin(1, 'テスト削除');
+
+        return [$conv1, $conv2, $conv3];
+    }
+
+    public function test_admin_can_access_conversations_list()
+    {
+        $admin = Admin::factory()->create();
+        $this->actingAs($admin, 'admin');
+        $this->createTestConversations();
+
+        $response = $this->get('/admin/conversations');
+
+        $response->assertOk();
+    }
+
+    // 以下のテストは詳細な実装が必要ですが、ここでは未完了としてマークします。
+
+    public function test_unauthenticated_user_cannot_access_conversations_list()
+    {
+        $response = $this->get('/admin/conversations');
+        $response->assertRedirect('/admin/login');
+    }
+
+    public function test_non_admin_user_cannot_access_conversations_list()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user); // auth as normal user
+        $response = $this->get('/admin/conversations');
+        $response->assertRedirect('/admin/login');
+    }
+
+    public function test_super_admin_can_access_conversations_list()
+    {
+        $admin = Admin::factory()->create(['role' => 'super_admin']);
+        $this->actingAs($admin, 'admin');
+        $response = $this->get('/admin/conversations');
+        $response->assertOk();
+    }
+
+    public function test_conversations_list_shows_all_conversations_except_support()
+    {
+        $admin = Admin::factory()->create();
+        $this->actingAs($admin, 'admin');
+        [$conv1, $conv2, $conv3] = $this->createTestConversations();
+
+        $response = $this->get('/admin/conversations');
+        $response->assertSee((string)$conv1->id);
+        $response->assertDontSee((string)$conv2->id);
+    }
+
+    // 以下のテストケースは今後実装予定
+    public function test_conversations_list_excludes_support_type_conversations() { $this->markTestIncomplete(); }
+    public function test_conversations_list_shows_deleted_conversations() { $this->markTestIncomplete(); }
+    public function test_conversations_list_pagination_works_correctly()
+    {
+        $admin = Admin::factory()->create();
+        $this->actingAs($admin, 'admin');
+
+        Conversation::factory()->count(21)->create(['type' => 'direct']);
+
+        $response = $this->get('/admin/conversations');
+        $response->assertOk()
+            ->assertViewHas('conversations', function ($conversations) {
+                return $conversations->count() === 20;
+            });
+
+        $response = $this->get('/admin/conversations?page=2');
+        $response->assertOk()
+            ->assertViewHas('conversations', function ($conversations) {
+                return $conversations->count() === 1;
+            });
+    }
+    public function test_conversations_list_shows_correct_message_count_using_withCount()
+    {
+        $admin = Admin::factory()->create();
+        $this->actingAs($admin, 'admin');
+
+        $conversation = Conversation::factory()->create(['type' => 'direct']);
+        $user = User::factory()->create();
+        Participant::create(['conversation_id' => $conversation->id, 'user_id' => $user->id]);
+
+        Message::factory()->count(3)->create([
+            'conversation_id' => $conversation->id,
+            'sender_id' => $user->id,
+        ]);
+
+        $response = $this->get('/admin/conversations');
+        $response->assertOk()
+            ->assertViewHas('conversations', function ($conversations) use ($conversation) {
+                $conv = $conversations->firstWhere('id', $conversation->id);
+                return $conv && isset($conv->messages_count) && $conv->messages_count === 3;
+            });
+    }
+
+    public function test_search_by_conversation_id_exact_match()
+    {
+        $admin = Admin::factory()->create();
+        $this->actingAs($admin, 'admin');
+
+        $conversation1 = Conversation::factory()->create(['type' => 'direct']);
+        $conversation2 = Conversation::factory()->create(['type' => 'direct']);
+
+        $response = $this->get('/admin/conversations?search=' . $conversation1->id);
+
+        $response->assertOk()
+            ->assertSee((string)$conversation1->id)
+            ->assertDontSee((string)$conversation2->id);
+    }
+    public function test_search_by_message_content_partial_match()
+    {
+        $admin = Admin::factory()->create();
+        $this->actingAs($admin, 'admin');
+
+        $conversation = Conversation::factory()->create(['type' => 'direct']);
+        $user = User::factory()->create();
+        Participant::create(['conversation_id' => $conversation->id, 'user_id' => $user->id]);
+        Message::factory()->create([
+            'conversation_id' => $conversation->id,
+            'sender_id' => $user->id,
+            'text_content' => 'これは検索対象のメッセージです',
+        ]);
+        Message::factory()->create([
+            'conversation_id' => $conversation->id,
+            'sender_id' => $user->id,
+            'text_content' => '検索対象外の削除メッセージ',
+            'deleted_at' => now(),
+        ]);
+
+        $response = $this->get('/admin/conversations?search=' . urlencode('検索対象'));
+
+        $response->assertOk()
+            ->assertSee((string)$conversation->id)
+            ->assertSee('これは検索対象のメッセージです');
+    }
+    public function test_search_by_user_name_partial_match() { $this->markTestIncomplete(); }
+    public function test_search_excludes_deleted_messages() { $this->markTestIncomplete(); }
+    public function test_search_excludes_admin_deleted_messages()
+    {
+        $admin = Admin::factory()->create();
+        $this->actingAs($admin, 'admin');
+
+        $conversation = Conversation::factory()->create(['type' => 'direct']);
+        $user = User::factory()->create();
+        Participant::create(['conversation_id' => $conversation->id, 'user_id' => $user->id]);
+
+        // 通常のメッセージ
+        Message::factory()->create([
+            'conversation_id' => $conversation->id,
+            'sender_id' => $user->id,
+            'text_content' => '通常のメッセージ',
+        ]);
+
+        // 管理者削除されたメッセージ
+        Message::factory()->create([
+            'conversation_id' => $conversation->id,
+            'sender_id' => $user->id,
+            'text_content' => '管理者削除されたメッセージ',
+            'admin_deleted_at' => now(),
+            'admin_deleted_by' => $admin->id,
+        ]);
+
+        // 削除されたメッセージ内容で検索
+        $response = $this->get('/admin/conversations?search=' . urlencode('管理者削除されたメッセージ'));
+        $response->assertOk()->assertDontSee((string)$conversation->id);
+
+        // 通常メッセージ内容で検索
+        $response = $this->get('/admin/conversations?search=' . urlencode('通常のメッセージ'));
+        $response->assertOk()->assertSee((string)$conversation->id);
+    }
+    public function test_search_returns_empty_when_no_match()
+    {
+        $admin = Admin::factory()->create();
+        $this->actingAs($admin, 'admin');
+
+        Conversation::factory()->create(['type' => 'direct']);
+
+        $response = $this->get('/admin/conversations?search=' . urlencode('存在しないキーワード'));
+
+        $response->assertOk()->assertSee('トークルームがありません');
+    }
+    public function test_search_maintains_pagination_parameters() { $this->markTestIncomplete(); }
+
+    public function test_conversation_detail_shows_all_information() { $this->markTestIncomplete(); }
+    public function test_conversation_detail_shows_deleted_conversation_info() { $this->markTestIncomplete(); }
+    public function test_conversation_detail_shows_participants_correctly() { $this->markTestIncomplete(); }
+    public function test_conversation_detail_shows_messages_with_pagination() { $this->markTestIncomplete(); }
+    public function test_conversation_detail_handles_null_sender_gracefully()
+    {
+        $admin = Admin::factory()->create();
+        $this->actingAs($admin, 'admin');
+        $conversation = Conversation::factory()->create(['type' => 'direct']);
+        Participant::create(['conversation_id' => $conversation->id, 'user_id' => User::factory()->create()->id]);
+
+        // メッセージの送信者が null (管理者メッセージ)
+        Message::factory()->adminMessage($admin->id)->create([
+            'conversation_id' => $conversation->id,
+            'text_content' => 'from admin',
+        ]);
+
+        $response = $this->get('/admin/conversations/' . $conversation->id);
+        $response->assertOk();
+    }
+    public function test_non_existent_conversation_returns_404()
+    {
+        $admin = Admin::factory()->create();
+        $this->actingAs($admin, 'admin');
+
+        $response = $this->get('/admin/conversations/999999');
+        $response->assertNotFound();
+    }
+
+    public function test_admin_can_delete_active_conversation()
+    {
+        $admin = Admin::factory()->create();
+        $this->actingAs($admin, 'admin');
+        $conversation = Conversation::factory()->create(['type' => 'direct']);
+
+        $this->withoutMiddleware(\App\Http\Middleware\VerifyCsrfToken::class);
+        $response = $this->delete('/admin/conversations/' . $conversation->id, [
+            'reason' => 'テスト削除理由',
+        ]);
+
+        $response->assertRedirect('/admin/conversations');
+        $this->assertDatabaseHas('conversations', [
+            'id' => $conversation->id,
+            'deleted_by' => $admin->id,
+            'deleted_reason' => 'テスト削除理由',
+        ]);
+    }
+
+    public function test_delete_logs_operation_correctly()
+    {
+        $admin = Admin::factory()->create();
+        $this->actingAs($admin, 'admin');
+        $conversation = Conversation::factory()->create(['type' => 'direct']);
+
+        $this->withoutMiddleware(\App\Http\Middleware\VerifyCsrfToken::class);
+        $this->delete('/admin/conversations/' . $conversation->id);
+
+        $this->assertDatabaseHas('operation_logs', [
+            'category' => 'backend',
+            'action' => 'delete_conversation_admin',
+            'description' => 'admin:' . $admin->id . ' conversation:' . $conversation->id,
+        ]);
+    }
+
+    public function test_admin_can_restore_deleted_conversation()
+    {
+        $admin = Admin::factory()->create();
+        $this->actingAs($admin, 'admin');
+
+        $conversation = Conversation::factory()->deleted()->create(['type' => 'direct']);
+        $this->assertNotNull($conversation->deleted_at);
+
+        $this->withoutMiddleware(\App\Http\Middleware\VerifyCsrfToken::class);
+        $response = $this->post('/admin/conversations/' . $conversation->id . '/restore');
+
+        $response->assertRedirect('/admin/conversations');
+        $conversation->refresh();
+        $this->assertNull($conversation->deleted_at);
+        $this->assertNull($conversation->deleted_by);
+        $this->assertNull($conversation->deleted_reason);
+    }
+    public function test_cannot_restore_active_conversation()
+    {
+        $admin = Admin::factory()->create();
+        $this->actingAs($admin, 'admin');
+
+        $conversation = Conversation::factory()->create(['type' => 'direct']);
+
+        $this->withoutMiddleware(\App\Http\Middleware\VerifyCsrfToken::class);
+        $response = $this->post('/admin/conversations/' . $conversation->id . '/restore');
+
+        $response->assertRedirect()
+            ->assertSessionHas('error', 'この会話は削除されていません。');
+        $conversation->refresh();
+        $this->assertNull($conversation->deleted_at);
+    }
+
+    public function test_restore_logs_operation_correctly()
+    {
+        $admin = Admin::factory()->create();
+        $this->actingAs($admin, 'admin');
+
+        $conversation = Conversation::factory()->deleted()->create(['type' => 'direct']);
+
+        $this->withoutMiddleware(\App\Http\Middleware\VerifyCsrfToken::class);
+        $this->post('/admin/conversations/' . $conversation->id . '/restore');
+
+        $this->assertDatabaseHas('operation_logs', [
+            'category' => 'backend',
+            'action' => 'restore_conversation_admin',
+            'description' => 'admin:' . $admin->id . ' conversation:' . $conversation->id,
+        ]);
+    }
+
+    public function test_restore_clears_deletion_fields()
+    {
+        $admin = Admin::factory()->create();
+        $this->actingAs($admin, 'admin');
+
+        $conversation = Conversation::factory()->deleted()->create(['type' => 'direct']);
+
+        $this->withoutMiddleware(\App\Http\Middleware\VerifyCsrfToken::class);
+        $this->post('/admin/conversations/' . $conversation->id . '/restore');
+
+        $conversation->refresh();
+        $this->assertNull($conversation->deleted_at);
+        $this->assertNull($conversation->deleted_by);
+        $this->assertNull($conversation->deleted_reason);
+    }
+}

--- a/tests/Unit/Admin/ConversationManagementUnitTest.php
+++ b/tests/Unit/Admin/ConversationManagementUnitTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Unit\Admin;
+
+use App\Models\Conversation;
+use App\Models\Message;
+use App\Models\Participant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ConversationManagementUnitTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_query_excludes_support_conversations()
+    {
+        Conversation::factory()->create(['type' => 'direct']);
+        Conversation::factory()->create(['type' => 'support']);
+
+        $query = Conversation::where('type', '!=', 'support');
+        $this->assertCount(1, $query->get());
+    }
+
+    public function test_withCount_returns_correct_message_count()
+    {
+        $conv = Conversation::factory()->create(['type' => 'direct']);
+        $user = User::factory()->create();
+        Participant::create(['conversation_id' => $conv->id, 'user_id' => $user->id]);
+        Message::factory()->create([
+            'conversation_id' => $conv->id,
+            'sender_id' => $user->id,
+            'text_content' => 'a',
+        ]);
+
+        $counted = Conversation::withCount('messages')->find($conv->id);
+        $this->assertEquals(1, $counted->messages_count);
+    }
+
+    public function test_search_query_builder_works_correctly()
+    {
+        $conv = Conversation::factory()->create(['type' => 'direct']);
+        $user = User::factory()->create(['name' => 'TestUser']);
+        Participant::create(['conversation_id' => $conv->id, 'user_id' => $user->id]);
+
+        $query = Conversation::where('type', '!=', 'support');
+        $search = 'TestUser';
+        $query->where(function ($q) use ($search) {
+            $q->orWhereHas('participants', function ($u) use ($search) {
+                $u->where('name', 'LIKE', "%$search%");
+            });
+        });
+
+        $this->assertCount(1, $query->get());
+    }
+}


### PR DESCRIPTION
## Summary
- implement pagination message count test
- add search tests and 404 handling for admin conversation management
- ensure admin restore errors report session message

## Testing
- `php -v` *(fails: command not found)*
- `./vendor/bin/phpunit --filter ConversationManagementTest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684157d1b6d88325a33af14b0af9b2e3