### PR TITLE
Implement basic group chat API

### DIFF
--- a/app/Http/Controllers/API/GroupController.php
+++ b/app/Http/Controllers/API/GroupController.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Models\Group;
+use App\Models\GroupMember;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class GroupController extends Controller
+{
+    public function index()
+    {
+        $user = Auth::user();
+        $groups = $user->ownedGroups()->withCount('members')->get();
+        return response()->json($groups);
+    }
+
+    public function store(Request $request)
+    {
+        $request->validate([
+            'name' => 'required|string|max:100',
+            'description' => 'nullable|string',
+            'max_members' => 'nullable|integer|min:1|max:500',
+        ]);
+        $user = Auth::user();
+        $group = null;
+        DB::transaction(function () use ($user, $request, &$group) {
+            $group = Group::create([
+                'owner_user_id' => $user->id,
+                'name' => $request->name,
+                'description' => $request->description,
+                'max_members' => $request->max_members ?? 50,
+            ]);
+            GroupMember::create([
+                'group_id' => $group->id,
+                'user_id' => $user->id,
+                'nickname' => $user->name,
+            ]);
+        });
+        return response()->json($group, 201);
+    }
+
+    public function show(Group $group)
+    {
+        $user = Auth::user();
+        if ($group->owner_user_id !== $user->id) {
+            return response()->json(['message' => __('errors.forbidden')], 403);
+        }
+        $group->load('members');
+        return response()->json($group);
+    }
+
+    public function update(Group $group, Request $request)
+    {
+        $request->validate([
+            'name' => 'sometimes|string|max:100',
+            'description' => 'nullable|string',
+            'max_members' => 'nullable|integer|min:1|max:500',
+        ]);
+        $user = Auth::user();
+        if ($group->owner_user_id !== $user->id) {
+            return response()->json(['message' => __('errors.forbidden')], 403);
+        }
+        $group->update($request->only('name', 'description', 'max_members'));
+        return response()->json($group);
+    }
+
+    public function destroy(Group $group)
+    {
+        $user = Auth::user();
+        if ($group->owner_user_id !== $user->id) {
+            return response()->json(['message' => __('errors.forbidden')], 403);
+        }
+        $group->delete();
+        return response()->json(['message' => __('messages.group_deleted')]);
+    }
+
+    public function addMember(Group $group, Request $request)
+    {
+        $request->validate([
+            'user_id' => 'required|exists:users,id',
+            'nickname' => 'nullable|string|max:50',
+        ]);
+        $user = Auth::user();
+        if ($group->owner_user_id !== $user->id) {
+            return response()->json(['message' => __('errors.forbidden')], 403);
+        }
+        if ($group->members()->where('user_id', $request->user_id)->exists()) {
+            return response()->json(['message' => __('errors.already_member')], 422);
+        }
+        $member = GroupMember::create([
+            'group_id' => $group->id,
+            'user_id' => $request->user_id,
+            'nickname' => $request->nickname ?? 'member',
+        ]);
+        return response()->json($member, 201);
+    }
+
+    public function removeMember(Group $group, GroupMember $member)
+    {
+        $user = Auth::user();
+        if ($group->owner_user_id !== $user->id) {
+            return response()->json(['message' => __('errors.forbidden')], 403);
+        }
+        if ($member->group_id !== $group->id) {
+            return response()->json(['message' => __('errors.invalid_member')], 422);
+        }
+        $member->delete();
+        return response()->json(['message' => __('messages.member_removed')]);
+   }
+}

--- a/app/Http/Controllers/API/GroupMessageController.php
+++ b/app/Http/Controllers/API/GroupMessageController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Models\Group;
+use App\Models\GroupMember;
+use App\Models\GroupMessage;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class GroupMessageController extends Controller
+{
+    public function index(Group $group)
+    {
+        $user = Auth::user();
+        if (!$group->members()->where('user_id', $user->id)->exists()) {
+            return response()->json(['message' => __('errors.forbidden')], 403);
+        }
+        $messages = $group->messages()->with('sender:id,name')->orderBy('created_at', 'desc')->paginate(20);
+        return response()->json($messages);
+    }
+
+    public function store(Group $group, Request $request)
+    {
+        $request->validate([
+            'message' => 'required|string',
+        ]);
+        $user = Auth::user();
+        if (!$group->members()->where('user_id', $user->id)->exists()) {
+            return response()->json(['message' => __('errors.forbidden')], 403);
+        }
+        $msg = GroupMessage::create([
+            'group_id' => $group->id,
+            'sender_user_id' => $user->id,
+            'message' => $request->message,
+            'target_type' => 'all',
+        ]);
+        return response()->json($msg, 201);
+    }
+}

--- a/database/factories/GroupFactory.php
+++ b/database/factories/GroupFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Group;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class GroupFactory extends Factory
+{
+    protected $model = Group::class;
+
+    public function definition(): array
+    {
+        return [
+            'owner_user_id' => User::factory(),
+            'name' => $this->faker->words(3, true),
+            'description' => $this->faker->sentence(),
+            'max_members' => 50,
+            'qr_code_token' => Str::random(32),
+        ];
+    }
+}

--- a/database/factories/GroupMemberFactory.php
+++ b/database/factories/GroupMemberFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\GroupMember;
+use App\Models\Group;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class GroupMemberFactory extends Factory
+{
+    protected $model = GroupMember::class;
+
+    public function definition(): array
+    {
+        return [
+            'group_id' => Group::factory(),
+            'user_id' => User::factory(),
+            'guest_identifier' => null,
+            'nickname' => $this->faker->name(),
+            'joined_at' => now(),
+            'is_active' => true,
+        ];
+    }
+}

--- a/database/factories/GroupMessageFactory.php
+++ b/database/factories/GroupMessageFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\GroupMessage;
+use App\Models\Group;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class GroupMessageFactory extends Factory
+{
+    protected $model = GroupMessage::class;
+
+    public function definition(): array
+    {
+        return [
+            'group_id' => Group::factory(),
+            'sender_user_id' => User::factory(),
+            'message' => $this->faker->sentence(),
+            'target_type' => 'all',
+            'target_ids' => null,
+            'created_at' => now(),
+        ];
+    }
+}

--- a/resources/lang/en/errors.php
+++ b/resources/lang/en/errors.php
@@ -1,0 +1,6 @@
+<?php
+return [
+    'forbidden' => 'Forbidden',
+    'already_member' => 'Already member',
+    'invalid_member' => 'Invalid member',
+];

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -1,0 +1,6 @@
+<?php
+return [
+    'success' => 'Success',
+    'group_deleted' => 'Group deleted successfully',
+    'member_removed' => 'Member removed successfully',
+];

--- a/resources/lang/ja/errors.php
+++ b/resources/lang/ja/errors.php
@@ -1,0 +1,6 @@
+<?php
+return [
+    'forbidden' => '操作する権限がありません。',
+    'already_member' => '既にグループに参加しています。',
+    'invalid_member' => '無効なメンバーです。',
+];

--- a/resources/lang/ja/messages.php
+++ b/resources/lang/ja/messages.php
@@ -1,0 +1,6 @@
+<?php
+return [
+    'success' => '成功しました。',
+    'group_deleted' => 'グループを削除しました。',
+    'member_removed' => 'メンバーを削除しました。',
+];

--- a/routes/api.php
+++ b/routes/api.php
@@ -89,6 +89,22 @@ Route::middleware(['auth:sanctum', 'check.user.status'])->group(function () {
     Route::post('/test', 'sendTestNotification'); // テスト通知の送信（開発用）
   });
 
+  // グループチャット関連API
+  Route::prefix('groups')->controller(\App\Http\Controllers\API\GroupController::class)->group(function () {
+    Route::get('/', 'index');
+    Route::post('/', 'store');
+    Route::get('/{group}', 'show');
+    Route::put('/{group}', 'update');
+    Route::delete('/{group}', 'destroy');
+    Route::post('/{group}/members', 'addMember');
+    Route::delete('/{group}/members/{member}', 'removeMember');
+  });
+
+  Route::prefix('groups/{group}/messages')->controller(\App\Http\Controllers\API\GroupMessageController::class)->group(function () {
+    Route::get('/', 'index');
+    Route::post('/', 'store');
+  });
+
   // Stripe 決済関連
   Route::post('/stripe/create-checkout-session', [StripeController::class, 'createCheckoutSession']);
 

--- a/tests/Feature/GroupChatTest.php
+++ b/tests/Feature/GroupChatTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Group;
+use App\Models\GroupMember;
+use App\Models\GroupMessage;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class GroupChatTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_create_group_and_add_member_and_send_message(): void
+    {
+        $owner = User::factory()->create();
+        $member = User::factory()->create();
+
+        Sanctum::actingAs($owner);
+
+        $create = $this->postJson('/api/groups', [
+            'name' => 'Test Group',
+        ]);
+        $create->assertCreated();
+        $groupId = $create->json('id');
+
+        $add = $this->postJson("/api/groups/{$groupId}/members", [
+            'user_id' => $member->id,
+            'nickname' => 'member1',
+        ]);
+        $add->assertCreated();
+
+        $msg = $this->postJson("/api/groups/{$groupId}/messages", [
+            'message' => 'hello',
+        ]);
+        $msg->assertCreated()->assertJsonFragment(['message' => 'hello']);
+
+        $this->assertDatabaseHas('group_messages', [
+            'group_id' => $groupId,
+            'sender_user_id' => $owner->id,
+            'message' => 'hello',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add GroupController and GroupMessageController
- expose group chat routes
- provide factories for groups, members and messages
- create GroupChatTest to cover group creation, member add and messaging
- localize group chat responses and add validation limit

## Testing
- `./vendor/bin/phpunit tests/Feature/GroupChatTest.php`
- `./vendor/bin/phpunit` *(fails: Errors 100)*

------
https://chatgpt.com/codex/tasks/task_e_6842f52e8ce88325a288ff5843483711