### PR TITLE
Implement Phase1 migrations and models

### DIFF
--- a/app/Models/PaymentTransaction.php
+++ b/app/Models/PaymentTransaction.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class PaymentTransaction extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'subscription_id',
+        'stripe_payment_intent_id',
+        'stripe_charge_id',
+        'amount',
+        'currency',
+        'status',
+        'type',
+        'refund_amount',
+        'metadata',
+        'paid_at',
+    ];
+
+    protected $casts = [
+        'amount' => 'decimal:2',
+        'refund_amount' => 'decimal:2',
+        'metadata' => 'array',
+        'paid_at' => 'datetime',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function subscription()
+    {
+        return $this->belongsTo(Subscription::class);
+    }
+
+    public function scopeSucceeded($query)
+    {
+        return $query->where('status', 'succeeded');
+    }
+
+    public function scopeThisMonth($query)
+    {
+        return $query->whereYear('created_at', now()->year)
+                     ->whereMonth('created_at', now()->month);
+    }
+
+    public function getFormattedAmountAttribute()
+    {
+        return number_format($this->amount) . ' ' . strtoupper($this->currency);
+    }
+
+    public function getNetAmountAttribute()
+    {
+        return $this->amount - $this->refund_amount;
+    }
+}

--- a/app/Models/Subscription.php
+++ b/app/Models/Subscription.php
@@ -5,6 +5,8 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use App\Models\PaymentTransaction;
 
 class Subscription extends Model
 {
@@ -26,5 +28,10 @@ class Subscription extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function paymentTransactions(): HasMany
+    {
+        return $this->hasMany(PaymentTransaction::class);
     }
 }

--- a/app/Models/WebhookLog.php
+++ b/app/Models/WebhookLog.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Carbon\Carbon;
+
+class WebhookLog extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'stripe_event_id',
+        'event_type',
+        'payload',
+        'status',
+        'error_message',
+        'processed_at',
+    ];
+
+    protected $casts = [
+        'payload' => 'array',
+        'processed_at' => 'datetime',
+    ];
+
+    public function scopeProcessed($query)
+    {
+        return $query->where('status', 'processed');
+    }
+
+    public function scopeFailed($query)
+    {
+        return $query->where('status', 'failed');
+    }
+
+    public function scopeRecent($query, $days = 7)
+    {
+        return $query->where('created_at', '>=', Carbon::now()->subDays($days));
+    }
+
+    public function getFormattedPayloadAttribute()
+    {
+        return json_encode($this->payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+    }
+}

--- a/database/migrations/2025_07_01_000007_create_webhook_logs_table.php
+++ b/database/migrations/2025_07_01_000007_create_webhook_logs_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('webhook_logs', function (Blueprint $table) {
+            $table->id();
+            $table->string('stripe_event_id')->unique();
+            $table->string('event_type');
+            $table->json('payload');
+            $table->enum('status', ['pending', 'processed', 'failed'])->default('pending');
+            $table->text('error_message')->nullable();
+            $table->timestamp('processed_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['event_type', 'status']);
+            $table->index('created_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('webhook_logs');
+    }
+};

--- a/database/migrations/2025_07_01_000008_create_payment_transactions_table.php
+++ b/database/migrations/2025_07_01_000008_create_payment_transactions_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('payment_transactions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->foreignId('subscription_id')->nullable()->constrained()->onDelete('set null');
+            $table->string('stripe_payment_intent_id')->unique();
+            $table->string('stripe_charge_id')->nullable();
+            $table->decimal('amount', 10, 2);
+            $table->string('currency', 3)->default('jpy');
+            $table->enum('status', ['pending', 'succeeded', 'failed', 'canceled', 'refunded'])->default('pending');
+            $table->enum('type', ['subscription', 'one_time'])->default('subscription');
+            $table->decimal('refund_amount', 10, 2)->default(0);
+            $table->json('metadata')->nullable();
+            $table->timestamp('paid_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['user_id', 'status']);
+            $table->index(['status', 'type']);
+            $table->index('created_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('payment_transactions');
+    }
+};


### PR DESCRIPTION
## Summary
- add migrations for webhook logs and payment transactions
- create WebhookLog and PaymentTransaction models
- extend Subscription model with paymentTransactions relation
- revert billing controller and UI to limit scope to Phase 1

## Testing
- `npm test` *(fails: Missing script)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ed6d4b17c8325b40d255748740419