### PR TITLE
Add admin billing routes and stripe service methods

### DIFF
--- a/app/Services/StripeService.php
+++ b/app/Services/StripeService.php
@@ -372,4 +372,36 @@ class StripeService extends BaseService
       ]);
     }
   }
+
+  /**
+   * 管理者によるStripeサブスクリプションのキャンセル
+   */
+  public function cancelSubscriptionAdmin(string $subscriptionId)
+  {
+    return $this->client->subscriptions->cancel($subscriptionId);
+  }
+
+  /**
+   * 管理者によるStripeサブスクリプションの再開
+   */
+  public function resumeSubscriptionAdmin(string $subscriptionId)
+  {
+    return $this->client->subscriptions->update($subscriptionId, [
+      'cancel_at_period_end' => false,
+    ]);
+  }
+
+  /**
+   * 支払いの返金を実行
+   */
+  public function refundPayment(string $chargeId, ?int $amount = null)
+  {
+    $params = ['charge' => $chargeId];
+
+    if ($amount) {
+      $params['amount'] = $amount;
+    }
+
+    return $this->client->refunds->create($params);
+  }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\Admin\AdminAuthController;
 use App\Http\Controllers\Admin\AdminDashboardController;
+use App\Http\Controllers\Admin\BillingController;
 
 Route::get('/', function () {
   return view('welcome');
@@ -94,5 +95,24 @@ Route::prefix('admin')->name('admin.')->group(function () {
     Route::get('admins/{id}/edit', [AdminDashboardController::class, 'editAdmin'])->name('admins.edit');
     Route::put('admins/{id}', [AdminDashboardController::class, 'updateAdmin'])->name('admins.update');
     Route::delete('admins/{id}', [AdminDashboardController::class, 'deleteAdmin'])->name('admins.delete');
+
+    // Billing Management Routes
+    Route::prefix('billing')->name('billing.')->group(function () {
+      Route::get('/', [BillingController::class, 'dashboard'])->name('dashboard');
+      Route::get('subscriptions', [BillingController::class, 'index'])->name('subscriptions.index');
+      Route::get('subscriptions/{id}', [BillingController::class, 'show'])->name('subscriptions.show');
+      Route::post('subscriptions/{id}/cancel', [BillingController::class, 'cancelSubscription'])->name('subscriptions.cancel');
+      Route::post('subscriptions/{id}/resume', [BillingController::class, 'resumeSubscription'])->name('subscriptions.resume');
+
+      Route::get('payments', [BillingController::class, 'payments'])->name('payments.index');
+      Route::get('payments/{id}', [BillingController::class, 'showPayment'])->name('payments.show');
+      Route::post('payments/{id}/refund', [BillingController::class, 'refundPayment'])->name('payments.refund');
+
+      Route::get('webhooks', [BillingController::class, 'webhooks'])->name('webhooks.index');
+      Route::get('webhooks/{id}', [BillingController::class, 'showWebhook'])->name('webhooks.show');
+
+      Route::get('analytics', [BillingController::class, 'analytics'])->name('analytics.index');
+      Route::get('analytics/export', [BillingController::class, 'exportAnalytics'])->name('analytics.export');
+    });
   });
 });


### PR DESCRIPTION
## Summary
- extend `StripeService` with admin-level subscription and refund operations
- nest billing routes inside existing admin group

## Testing
- `composer install`
- `./vendor/bin/phpunit --stop-on-failure` *(fails: could not find driver for sqlite)*

------
https://chatgpt.com/codex/tasks/task_e_684f6f6a30fc83259b5de70cba718a9f