### PR TITLE
Add admin views for webhook logs and analytics

### DIFF
--- a/resources/views/admin/billing/analytics/index.blade.php
+++ b/resources/views/admin/billing/analytics/index.blade.php
@@ -1,0 +1,110 @@
+@extends('admin.layouts.app')
+
+@section('title', '分析・レポート')
+
+@section('content')
+<div class="row mb-4">
+  <div class="col-12">
+    <h1 class="h3 mb-0">
+      <i class="fas fa-chart-line me-2"></i>分析・レポート
+    </h1>
+    <p class="text-muted">売上や解約率の分析</p>
+  </div>
+</div>
+
+<div class="row mb-4">
+  <div class="col-12">
+    <div class="card">
+      <div class="card-body">
+        <form method="GET" action="{{ route('admin.billing.analytics.index') }}" class="row g-3">
+          <div class="col-md-4">
+            <label for="period" class="form-label">期間</label>
+            <select id="period" name="period" class="form-select">
+              <option value="3months" {{ request('period') == '3months' ? 'selected' : '' }}>直近3ヶ月</option>
+              <option value="6months" {{ request('period') == '6months' ? 'selected' : '' }}>直近6ヶ月</option>
+              <option value="12months" {{ request('period', '12months') == '12months' ? 'selected' : '' }}>直近12ヶ月</option>
+            </select>
+          </div>
+          <div class="col-md-8 d-flex align-items-end">
+            <button type="submit" class="btn btn-primary me-2">
+              <i class="fas fa-search me-1"></i>表示
+            </button>
+            <a href="{{ route('admin.billing.analytics.index') }}" class="btn btn-secondary me-2">
+              <i class="fas fa-times me-1"></i>クリア
+            </a>
+            <a href="{{ route('admin.billing.analytics.export', request()->query()) }}" class="btn btn-outline-success">
+              <i class="fas fa-file-csv me-1"></i>CSVエクスポート
+            </a>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="row mb-4">
+  <div class="col-md-4 mb-3">
+    <div class="card h-100">
+      <div class="card-body text-center">
+        <h6 class="text-muted">MRR</h6>
+        <h3 class="mb-0">{{ number_format($mrr['total']) }}円</h3>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-4 mb-3">
+    <div class="card h-100">
+      <div class="card-body text-center">
+        <h6 class="text-muted">チャーン率</h6>
+        <h3 class="mb-0">{{ $churnData['rate'] }}%</h3>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-4 mb-3">
+    <div class="card h-100">
+      <div class="card-body text-center">
+        <h6 class="text-muted">LTV</h6>
+        <h3 class="mb-0">{{ number_format($ltv['ltv']) }}円</h3>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="row mb-4">
+  <div class="col-12">
+    <div class="card">
+      <div class="card-header">
+        <h5 class="card-title mb-0">売上推移</h5>
+      </div>
+      <div class="card-body">
+        <canvas id="revenueChart" height="200"></canvas>
+      </div>
+    </div>
+  </div>
+</div>
+@endsection
+
+@section('scripts')
+<script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    const ctx = document.getElementById('revenueChart').getContext('2d');
+    new Chart(ctx, {
+      type: 'line',
+      data: {
+        labels: @json(array_column($revenueData, 'month')),
+        datasets: [{
+          label: '売上',
+          data: @json(array_column($revenueData, 'revenue')),
+          borderColor: '#3b5b7a',
+          backgroundColor: 'rgba(59, 91, 122, 0.1)',
+          tension: 0.3
+        }]
+      },
+      options: {
+        scales: { y: { beginAtZero: true } },
+        plugins: { legend: { display: false } }
+      }
+    });
+  });
+</script>
+@endsection

--- a/resources/views/admin/billing/webhooks/index.blade.php
+++ b/resources/views/admin/billing/webhooks/index.blade.php
@@ -1,0 +1,115 @@
+@extends('admin.layouts.app')
+
+@section('title', 'Webhookログ')
+
+@section('content')
+<div class="row mb-4">
+  <div class="col-12">
+    <div class="d-flex justify-content-between align-items-center">
+      <h1 class="h3 mb-0">
+        <i class="fas fa-code-branch me-2"></i>Webhook ログ
+      </h1>
+    </div>
+  </div>
+</div>
+
+<div class="row mb-4">
+  <div class="col-12">
+    <div class="card">
+      <div class="card-body">
+        <form method="GET" action="{{ route('admin.billing.webhooks.index') }}" class="row g-3">
+          <div class="col-md-4">
+            <label for="event_type" class="form-label">イベントタイプ</label>
+            <select id="event_type" name="event_type" class="form-select">
+              <option value="">全て</option>
+              @foreach($eventTypes as $type)
+              <option value="{{ $type }}" {{ request('event_type') == $type ? 'selected' : '' }}>{{ $type }}</option>
+              @endforeach
+            </select>
+          </div>
+          <div class="col-md-4">
+            <label for="status" class="form-label">ステータス</label>
+            <select id="status" name="status" class="form-select">
+              <option value="">全て ({{ $statusCounts['all'] }})</option>
+              <option value="processed" {{ request('status') == 'processed' ? 'selected' : '' }}>成功 ({{ $statusCounts['processed'] }})</option>
+              <option value="failed" {{ request('status') == 'failed' ? 'selected' : '' }}>失敗 ({{ $statusCounts['failed'] }})</option>
+              <option value="pending" {{ request('status') == 'pending' ? 'selected' : '' }}>未処理 ({{ $statusCounts['pending'] }})</option>
+            </select>
+          </div>
+          <div class="col-md-4 d-flex align-items-end">
+            <button type="submit" class="btn btn-primary me-2">
+              <i class="fas fa-search me-1"></i>検索
+            </button>
+            <a href="{{ route('admin.billing.webhooks.index') }}" class="btn btn-secondary">
+              <i class="fas fa-times me-1"></i>クリア
+            </a>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-12">
+    <div class="card">
+      <div class="card-header">
+        <h5 class="card-title mb-0">Webhookログ一覧 ({{ $webhooks->total() }}件)</h5>
+      </div>
+      <div class="card-body">
+        @if($webhooks->count() > 0)
+        <div class="table-responsive">
+          <table class="table table-hover">
+            <thead class="table-light">
+              <tr>
+                <th>ID</th>
+                <th>イベントID</th>
+                <th>タイプ</th>
+                <th>ステータス</th>
+                <th>受信日時</th>
+                <th>処理日時</th>
+                <th>操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              @foreach($webhooks as $log)
+              <tr>
+                <td>#{{ $log->id }}</td>
+                <td>{{ $log->stripe_event_id }}</td>
+                <td>{{ $log->event_type }}</td>
+                <td>
+                  @if($log->status === 'processed')
+                  <span class="badge bg-success">成功</span>
+                  @elseif($log->status === 'failed')
+                  <span class="badge bg-danger">失敗</span>
+                  @else
+                  <span class="badge bg-secondary">未処理</span>
+                  @endif
+                </td>
+                <td>{{ $log->created_at->format('Y/m/d H:i') }}</td>
+                <td>{{ optional($log->processed_at)->format('Y/m/d H:i') ?? '-' }}</td>
+                <td>
+                  <a href="{{ route('admin.billing.webhooks.show', $log->id) }}" class="btn btn-sm btn-outline-primary">
+                    <i class="fas fa-eye me-1"></i>詳細
+                  </a>
+                </td>
+              </tr>
+              @endforeach
+            </tbody>
+          </table>
+        </div>
+        <div class="d-flex justify-content-between align-items-center mt-3">
+          <div class="text-muted">{{ $webhooks->firstItem() }}〜{{ $webhooks->lastItem() }}件目 / 全{{ $webhooks->total() }}件</div>
+          <div>{{ $webhooks->links() }}</div>
+        </div>
+        @else
+        <div class="text-center py-5">
+          <i class="fas fa-code-branch fa-3x text-muted mb-3"></i>
+          <h5 class="text-muted">Webhook ログが見つかりません</h5>
+        </div>
+        @endif
+      </div>
+    </div>
+  </div>
+</div>
+@endsection

--- a/resources/views/admin/billing/webhooks/show.blade.php
+++ b/resources/views/admin/billing/webhooks/show.blade.php
@@ -1,0 +1,63 @@
+@extends('admin.layouts.app')
+
+@section('title', 'Webhook詳細')
+
+@section('content')
+<div class="row mb-4">
+  <div class="col-12">
+    <nav aria-label="breadcrumb">
+      <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ route('admin.billing.webhooks.index') }}">Webhookログ</a></li>
+        <li class="breadcrumb-item active">#{{ $webhook->id }}</li>
+      </ol>
+    </nav>
+    <h1 class="h3 mb-0">
+      <i class="fas fa-code-branch me-2"></i>Webhook 詳細
+    </h1>
+  </div>
+</div>
+
+<div class="row mb-4">
+  <div class="col-md-6">
+    <div class="card mb-3">
+      <div class="card-header">基本情報</div>
+      <div class="card-body">
+        <dl class="row mb-0">
+          <dt class="col-sm-4">ID</dt>
+          <dd class="col-sm-8">#{{ $webhook->id }}</dd>
+          <dt class="col-sm-4">イベントID</dt>
+          <dd class="col-sm-8">{{ $webhook->stripe_event_id }}</dd>
+          <dt class="col-sm-4">タイプ</dt>
+          <dd class="col-sm-8">{{ $webhook->event_type }}</dd>
+          <dt class="col-sm-4">ステータス</dt>
+          <dd class="col-sm-8">
+            @if($webhook->status === 'processed')
+            <span class="badge bg-success">成功</span>
+            @elseif($webhook->status === 'failed')
+            <span class="badge bg-danger">失敗</span>
+            @else
+            <span class="badge bg-secondary">未処理</span>
+            @endif
+          </dd>
+          <dt class="col-sm-4">受信日時</dt>
+          <dd class="col-sm-8">{{ $webhook->created_at->format('Y/m/d H:i') }}</dd>
+          <dt class="col-sm-4">処理日時</dt>
+          <dd class="col-sm-8">{{ optional($webhook->processed_at)->format('Y/m/d H:i') ?? '-' }}</dd>
+          @if($webhook->error_message)
+          <dt class="col-sm-4">エラー</dt>
+          <dd class="col-sm-8">{{ $webhook->error_message }}</dd>
+          @endif
+        </dl>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="card mb-3">
+      <div class="card-header">ペイロード</div>
+      <div class="card-body">
+        <pre class="mb-0">{{ $webhook->formatted_payload }}</pre>
+      </div>
+    </div>
+  </div>
+</div>
+@endsection


### PR DESCRIPTION
## Summary
- add Webhook log list and detail templates
- add Analytics report template with metrics and chart

## Testing
- `php -v` *(fails: command not found)*
- `composer install` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684f93b31b2c832589d997a9cb516feb