### PR TITLE
Refactor conversation logic into service layer

### DIFF
--- a/app/Repositories/ChatRoomRepository.php
+++ b/app/Repositories/ChatRoomRepository.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\ChatRoom;
+use App\Models\GroupMember;
+use App\Models\User;
+use Illuminate\Support\Collection;
+
+class ChatRoomRepository
+{
+    /**
+     * 指定ユーザーが参加するチャットルームID一覧を取得
+     */
+    public function getChatRoomIdsForUser(User $user): array
+    {
+        $chatRoomIds = ChatRoom::where(function ($query) use ($user) {
+            $query->where('participant1_id', $user->id)
+                  ->orWhere('participant2_id', $user->id);
+        })->pluck('id')->toArray();
+
+        $memberGroupIds = GroupMember::where('user_id', $user->id)
+            ->whereNull('left_at')
+            ->pluck('group_id')
+            ->toArray();
+
+        if (!empty($memberGroupIds)) {
+            // グループ関連チャットを一度に取得してマージ
+            $groupChatRoomIds = ChatRoom::whereIn('group_id', $memberGroupIds)
+                ->where('type', 'group_chat')
+                ->pluck('id')
+                ->toArray();
+
+            // グループ内個別チャットルームも取得
+            $memberChatRoomIds = ChatRoom::whereIn('group_id', $memberGroupIds)
+                ->where('type', 'member_chat')
+                ->where(function ($query) use ($user) {
+                    $query->where('participant1_id', $user->id)
+                          ->orWhere('participant2_id', $user->id);
+                })
+                ->pluck('id')
+                ->toArray();
+
+            $chatRoomIds = array_unique(array_merge($chatRoomIds, $groupChatRoomIds, $memberChatRoomIds));
+        }
+
+        return $chatRoomIds;
+    }
+
+    /**
+     * ID一覧からチャットルーム情報を取得
+     */
+    public function fetchChatRoomsForIds(array $chatRoomIds): \Illuminate\Support\Collection
+    {
+        // 参加者・グループ・最新メッセージを事前ロードして一括取得
+        return ChatRoom::whereIn('id', $chatRoomIds)
+            ->whereIn('type', ['member_chat', 'friend_chat', 'group_chat', 'support_chat'])
+            ->whereNull('deleted_at')
+            ->with([
+                'participant1' => function ($query) {
+                    $query->select('id', 'name', 'friend_id', 'deleted_at', 'is_banned');
+                },
+                'participant2' => function ($query) {
+                    $query->select('id', 'name', 'friend_id', 'deleted_at', 'is_banned');
+                },
+                'group' => function ($query) {
+                    $query->select('id', 'name', 'owner_user_id');
+                },
+                'latestMessage' => function ($query) {
+                    $query->with([
+                        'sender' => function ($senderQuery) {
+                            $senderQuery->select('id', 'name');
+                        },
+                        'adminSender' => function ($adminQuery) {
+                            $adminQuery->select('id', 'name');
+                        },
+                    ]);
+                },
+            ])
+            ->get();
+    }
+
+    public function findFriendChatRoom(User $user1, User $user2): ?ChatRoom
+    {
+        return ChatRoom::where('type', 'friend_chat')
+            ->where(function ($query) use ($user1, $user2) {
+                $query->where(function ($q) use ($user1, $user2) {
+                    $q->where('participant1_id', $user1->id)
+                      ->where('participant2_id', $user2->id);
+                })->orWhere(function ($q) use ($user1, $user2) {
+                    $q->where('participant1_id', $user2->id)
+                      ->where('participant2_id', $user1->id);
+                });
+            })
+            ->withTrashed()
+            ->first();
+    }
+
+    public function createFriendChatRoom(User $currentUser, User $recipient): ChatRoom
+    {
+        return ChatRoom::create([
+            'type' => 'friend_chat',
+            'group_id' => null,
+            'participant1_id' => $currentUser->id,
+            'participant2_id' => $recipient->id,
+        ]);
+    }
+}

--- a/app/Services/ChatRoomService.php
+++ b/app/Services/ChatRoomService.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Friendship;
+use App\Models\User;
+use App\Models\ChatRoom;
+use App\Models\ChatRoomRead;
+use App\Repositories\ChatRoomRepository;
+use Illuminate\Support\Facades\DB;
+
+class ChatRoomService extends BaseService
+{
+    private ChatRoomRepository $repository;
+
+    public function __construct(ChatRoomRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * 指定されたチャットルームで現在のユーザー以外の参加者を取得
+     */
+    private function getOtherParticipant(ChatRoom $chatRoom, User $currentUser): ?User
+    {
+        return $chatRoom->participant1_id === $currentUser->id
+            ? $chatRoom->participant2
+            : $chatRoom->participant1;
+    }
+
+    /**
+     * チャットルームのレスポンス用データを構築
+     */
+    private function buildChatRoomPayload(ChatRoom $chatRoom, User $currentUser, bool $existing): array
+    {
+        $chatRoom->load([
+            'participant1' => fn($q) => $q->select('id', 'name', 'friend_id', 'deleted_at'),
+            'participant2' => fn($q) => $q->select('id', 'name', 'friend_id', 'deleted_at'),
+            'latestMessage' => function ($q) {
+                $q->with([
+                    'sender' => fn($s) => $s->select('id', 'name'),
+                    'adminSender' => fn($a) => $a->select('id', 'name'),
+                ]);
+            },
+        ]);
+
+        $other = $this->getOtherParticipant($chatRoom, $currentUser);
+
+        return [
+            'id' => $chatRoom->id,
+            'type' => $chatRoom->type,
+            'room_token' => $chatRoom->room_token,
+            'group_id' => $chatRoom->group_id,
+            'participant1_id' => $chatRoom->participant1_id,
+            'participant2_id' => $chatRoom->participant2_id,
+            'created_at' => $chatRoom->created_at,
+            'updated_at' => $chatRoom->updated_at,
+            'other_participant' => $other ? [
+                'id' => $other->id,
+                'name' => $other->name,
+                'friend_id' => $other->friend_id,
+            ] : null,
+            'latest_message' => $chatRoom->latestMessage,
+            'unread_messages_count' => $existing
+                ? ChatRoomRead::getUnreadCount($currentUser->id, $chatRoom->id)
+                : 0,
+        ];
+    }
+
+    public function getUserChatRoomsList(User $user, int $page = 1, int $perPage = 15): array
+    {
+        $chatRoomIds = $this->repository->getChatRoomIdsForUser($user);
+        $chatRooms   = $this->repository->fetchChatRoomsForIds($chatRoomIds);
+
+        $memberGroupIds = \App\Models\GroupMember::where('user_id', $user->id)
+            ->whereNull('left_at')
+            ->pluck('group_id')
+            ->toArray();
+        $friendIds = $user->friends()->pluck('id')->toArray();
+
+        $filtered = $chatRooms->filter(function ($chatRoom) use ($user, $friendIds, $memberGroupIds) {
+            if ($chatRoom->type === 'friend_chat') {
+                $other = $this->getOtherParticipant($chatRoom, $user);
+                return $other && !$other->isDeleted() && !$other->is_banned;
+            }
+
+            if ($chatRoom->type === 'support_chat') {
+                return (bool) $chatRoom->latestMessage;
+            }
+
+            if ($chatRoom->type === 'group_chat') {
+                return !($chatRoom->group && $chatRoom->group->owner_user_id === $user->id);
+            }
+
+            if ($chatRoom->type === 'member_chat') {
+                if ($chatRoom->group && $chatRoom->group->owner_user_id === $user->id) {
+                    return false;
+                }
+                if ($chatRoom->group && !in_array($chatRoom->group->id, $memberGroupIds)) {
+                    return false;
+                }
+                $other = $this->getOtherParticipant($chatRoom, $user);
+                return $other && !$other->isDeleted() && !$other->is_banned;
+            }
+
+            return true;
+        });
+
+        $unreadCounts = ChatRoomRead::getUnreadCountsForChatRooms($user->id, $filtered->pluck('id')->toArray());
+
+        $processed = $filtered->map(function ($chatRoom) use ($user, $unreadCounts) {
+            $unreadCount = $unreadCounts[$chatRoom->id] ?? 0;
+            $result = [
+                'id' => $chatRoom->id,
+                'type' => $chatRoom->type,
+                'room_token' => $chatRoom->room_token,
+                'group_id' => $chatRoom->group_id,
+                'participant1_id' => $chatRoom->participant1_id,
+                'participant2_id' => $chatRoom->participant2_id,
+                'created_at' => $chatRoom->created_at,
+                'updated_at' => $chatRoom->updated_at,
+                'latest_message' => $chatRoom->latestMessage,
+                'unread_messages_count' => $unreadCount,
+            ];
+
+            if ($chatRoom->type === 'group_chat' && $chatRoom->group) {
+                $result['name'] = $chatRoom->group->name;
+                $result['group_name'] = $chatRoom->group->name;
+                $result['participant_count'] = $chatRoom->group->getMembersCount();
+                $result['participants'] = [[
+                    'id' => $chatRoom->group->id,
+                    'name' => $chatRoom->group->name,
+                    'friend_id' => null,
+                ]];
+            } elseif ($chatRoom->type === 'member_chat' && $chatRoom->group) {
+                $groupOwner = User::find($chatRoom->group->owner_user_id);
+                $other = $this->getOtherParticipant($chatRoom, $user);
+                $result['name'] = $chatRoom->group->name;
+                $result['group_name'] = $chatRoom->group->name;
+                $result['group_owner'] = $groupOwner ? [
+                    'id' => $groupOwner->id,
+                    'name' => $groupOwner->name,
+                    'friend_id' => $groupOwner->friend_id,
+                ] : null;
+                $result['other_participant'] = $other;
+                $result['participants'] = $other ? [[
+                    'id' => $other->id,
+                    'name' => $other->name,
+                    'friend_id' => $other->friend_id,
+                ]] : [];
+            } elseif ($chatRoom->type === 'support_chat') {
+                $result['name'] = 'サポート';
+                $result['participants'] = [[
+                    'id' => 0,
+                    'name' => 'サポート',
+                    'friend_id' => null,
+                ]];
+            } else {
+                $other = $this->getOtherParticipant($chatRoom, $user);
+                $result['other_participant'] = $other;
+                $result['participants'] = $other ? [[
+                    'id' => $other->id,
+                    'name' => $other->name,
+                    'friend_id' => $other->friend_id,
+                ]] : [];
+            }
+
+            return $result;
+        })->sortByDesc(function ($room) {
+            return $room['latest_message'] ? $room['latest_message']->sent_at : $room['created_at'];
+        })->values();
+
+        $offset = ($page - 1) * $perPage;
+        $items = $processed->slice($offset, $perPage)->values();
+
+        return [
+            'data' => $items,
+            'current_page' => $page,
+            'per_page' => $perPage,
+            'total' => $processed->count(),
+            'last_page' => ceil($processed->count() / $perPage),
+        ];
+    }
+
+    public function createFriendChatRoom(User $currentUser, int $recipientId): array
+    {
+        $recipient = User::find($recipientId);
+        if (!$recipient) {
+            return $this->errorResponse('not_found', '指定された受信ユーザーが見つかりません。') + ['http_status' => 404];
+        }
+        if ($recipient->isDeleted()) {
+            return $this->errorResponse('deleted_user', '指定されたユーザーは削除されています。') + ['http_status' => 403];
+        }
+
+        $friendship = Friendship::getFriendship($currentUser->id, $recipientId);
+        if (!$friendship || $friendship->status !== Friendship::STATUS_ACCEPTED) {
+            return $this->errorResponse('not_friend', '友達関係にないユーザーとはチャットを開始できません。') + ['http_status' => 403];
+        }
+
+        $existing = $this->repository->findFriendChatRoom($currentUser, $recipient);
+        if ($existing) {
+            return [
+                'status' => self::STATUS_SUCCESS,
+                'http_status' => 200,
+                'data' => $this->buildChatRoomPayload($existing, $currentUser, true),
+            ];
+        }
+
+        $chatRoom = null;
+        DB::transaction(function () use ($currentUser, $recipient, &$chatRoom) {
+            $chatRoom = $this->repository->createFriendChatRoom($currentUser, $recipient);
+        });
+
+        if ($chatRoom) {
+            return [
+                'status' => self::STATUS_SUCCESS,
+                'http_status' => 201,
+                'data' => $this->buildChatRoomPayload($chatRoom, $currentUser, false),
+            ];
+        }
+
+        return $this->errorResponse('create_failed', 'チャットルームの作成に失敗しました。') + ['http_status' => 500];
+    }
+}

--- a/tests/Unit/ChatRoomServiceTest.php
+++ b/tests/Unit/ChatRoomServiceTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use App\Services\ChatRoomService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ChatRoomServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private ChatRoomService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = $this->app->make(ChatRoomService::class);
+    }
+
+    public function test_create_friend_chat_room_and_list(): void
+    {
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+        $user1->sendFriendRequest($user2->id);
+        $user2->acceptFriendRequest($user1->id);
+
+        $result = $this->service->createFriendChatRoom($user1, $user2->id);
+        $this->assertEquals(ChatRoomService::STATUS_SUCCESS, $result['status']);
+        $this->assertEquals(201, $result['http_status']);
+
+        $list = $this->service->getUserChatRoomsList($user1);
+        $this->assertCount(1, $list['data']);
+        $this->assertEquals($result['data']['id'], $list['data'][0]['id']);
+    }
+
+    public function test_create_friend_chat_room_returns_existing(): void
+    {
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+        $user1->sendFriendRequest($user2->id);
+        $user2->acceptFriendRequest($user1->id);
+
+        $first = $this->service->createFriendChatRoom($user1, $user2->id);
+        $second = $this->service->createFriendChatRoom($user1, $user2->id);
+
+        $this->assertEquals(ChatRoomService::STATUS_SUCCESS, $second['status']);
+        $this->assertEquals(200, $second['http_status']);
+        $this->assertEquals($first['data']['id'], $second['data']['id']);
+    }
+
+    public function test_create_friend_chat_room_with_deleted_user_fails(): void
+    {
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create(['deleted_at' => now()]);
+
+        $result = $this->service->createFriendChatRoom($user1, $user2->id);
+
+        $this->assertEquals(ChatRoomService::STATUS_ERROR, $result['status']);
+        $this->assertEquals('deleted_user', $result['error_type']);
+        $this->assertEquals(403, $result['http_status']);
+    }
+
+    public function test_create_friend_chat_room_with_non_friend_fails(): void
+    {
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+
+        $result = $this->service->createFriendChatRoom($user1, $user2->id);
+
+        $this->assertEquals(ChatRoomService::STATUS_ERROR, $result['status']);
+        $this->assertEquals('not_friend', $result['error_type']);
+        $this->assertEquals(403, $result['http_status']);
+    }
+
+    public function test_get_user_chat_rooms_list_filters_and_paginates(): void
+    {
+        $user = User::factory()->create();
+        $friends = User::factory()->count(4)->create();
+
+        foreach ($friends as $friend) {
+            $user->sendFriendRequest($friend->id);
+            $friend->acceptFriendRequest($user->id);
+            $this->service->createFriendChatRoom($user, $friend->id);
+        }
+
+        // one friend is deleted -> should not appear
+        $friends[0]->update(['deleted_at' => now()]);
+
+        $page1 = $this->service->getUserChatRoomsList($user, 1, 2);
+        $this->assertCount(2, $page1['data']);
+        $this->assertEquals(3, $page1['total']);
+        $this->assertEquals(2, $page1['last_page']);
+
+        $page2 = $this->service->getUserChatRoomsList($user, 2, 2);
+        $this->assertCount(1, $page2['data']);
+    }
+}


### PR DESCRIPTION
## Summary
- clean up `ConversationsController` and delegate chat creation details to service
- expand `ChatRoomService` with response helpers and typed methods
- document query logic in `ChatRoomRepository`
- enhance unit tests for chat room service with error and pagination checks

## Testing
- `php --version` *(fails: command not found)*
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686523d1d2ec832588d1724ae4be3b54